### PR TITLE
allow required_providers blocks to be generated

### DIFF
--- a/src/TerraformGenerator.ts
+++ b/src/TerraformGenerator.ts
@@ -2,7 +2,7 @@ import child_process from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import shell from 'shelljs';
-import { Block, Comment, Resource, Data, Module, Output, Provider, Variable, Backend, Provisioner, ResourceToDataOptions, Locals, Import, ImportArgs, VariableArgs, ModuleArgs, OutputArgs } from './blocks';
+import { Block, Comment, Resource, Data, Module, Output, Provider, Variable, Backend, Provisioner, ResourceToDataOptions, Locals, Import, ImportArgs, VariableArgs, ModuleArgs, OutputArgs, RequiredProviders, RequiredProvidersArgs } from './blocks';
 import { TerraformArgs, Util } from './utils';
 
 /**
@@ -294,6 +294,19 @@ export class TerraformGenerator {
     this.addBlocks(block);
     return block;
   }
+
+  /**
+   * Add required providers into Terraform.
+   *
+   * Refer to Terraform documentation on what can be put as type & arguments.
+   *
+   * @param args arguments
+   */
+    requiredProviders(args: RequiredProvidersArgs): RequiredProviders {
+      const block = new RequiredProviders(args);
+      this.addBlocks(block);
+      return block;
+    }
 
   /**
    * Add backend into Terraform.

--- a/src/blocks/RequiredProviders.ts
+++ b/src/blocks/RequiredProviders.ts
@@ -1,0 +1,38 @@
+import { Argument, Attribute } from '../arguments';
+import { Util } from '../utils';
+import { Block, Resource } from '.';
+
+/**
+ * @category Block
+ */
+export interface RequiredProvidersArgs {
+  to: Resource;
+  id: string;
+  provider?: Argument;
+}
+
+/**
+ * @category Block
+ */
+export class RequiredProviders extends Block<RequiredProvidersArgs> {
+
+  /**
+   * Construct import.
+   *
+   * Refer to Terraform documentation on what can be put as arguments.
+   *
+   * @param args arguments
+   */
+  constructor(args: RequiredProvidersArgs) {
+    super('required_providers', [], args, undefined, true);
+  }
+
+  override asArgument(): Argument {
+    throw Util.inaccessibleMethod();
+  }
+
+  override attr(_name: string): Attribute {
+    throw Util.inaccessibleMethod();
+  }
+
+}

--- a/src/blocks/index.ts
+++ b/src/blocks/index.ts
@@ -8,5 +8,6 @@ export * from './Module';
 export * from './Output';
 export * from './Provider';
 export * from './Provisioner';
+export * from './RequiredProviders';
 export * from './Resource';
 export * from './Variable';

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
   Output, OutputArgs,
   Provider,
   Provisioner, ProvisionerArgs, ProvisionerType,
+  RequiredProviders, RequiredProvidersArgs,
   Resource, ResourceToDataOptions,
   Variable, VariableArgs
 } from './blocks';

--- a/test/blocks/RequiredProviders.test.ts
+++ b/test/blocks/RequiredProviders.test.ts
@@ -1,0 +1,16 @@
+import { arg4 } from '..';
+import { Argument } from '../../src/arguments';
+import { RequiredProviders, Resource } from '../../src/blocks';
+
+const resource = new Resource('type', 'name', arg4);
+
+test('RequiredProviders', () => {
+  const requiredProviders = new RequiredProviders({
+    to: resource,
+    id: 'id',
+    provider: new Argument('arg')
+  });
+  expect(requiredProviders.toTerraform()).toMatchSnapshot();
+  expect(() => requiredProviders.asArgument()).toThrow();
+  expect(() => requiredProviders.attr('attr')).toThrow();
+});

--- a/test/blocks/__snapshots__/RequiredProviders.test.ts.snap
+++ b/test/blocks/__snapshots__/RequiredProviders.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+ 
+exports[`RequiredProviders 1`] = `
+"required_providers{
+to = type.name
+id = &tfgquot;id&tfgquot;
+provider = arg
+}
+ 
+"
+`;


### PR DESCRIPTION
This PR adds support for Terraform [`required_providers ` blocks](https://developer.hashicorp.com/terraform/language/providers/requirements#requiring-providers).