### PR TITLE
Escape special characters in argument keys

### DIFF
--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -46,7 +46,8 @@ export class Util {
         return '';
       }
 
-      if (key.indexOf(' ') > 0) {
+      // Escape key if it contains special characters.
+      if (!key.match(/^[a-zA-Z0-9_]+$/)) {
         key = `"${key}"`;
       }
 


### PR DESCRIPTION
If an argument key contains special characters (other than a-z A-Z 0-9 and underscores), it needs to be escaped with quotes.